### PR TITLE
Update or unpin crates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: tests
+on: [push]
+jobs:
+  tests:
+    name: tests
+    runs-on: ubuntu-latest
+    env:
+      # For incremental builds
+      CARGO_INCREMENTAL: 1
+    steps:
+      - uses: actions/checkout@v3
+        # For incremental builds
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # For incremental builds
+      - name: git-restore-mtime
+        uses: chetan/git-restore-mtime-action@v1.2
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - run: cargo fmt --all -- --check
+
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - run: cargo test
+
+      - run: cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ name = "sxd_html"
 version = "0.1.0"
 
 [dependencies]
-html5ever = "0.25"
-sxd-document = "0.3"
+html5ever = "*"
+sxd-document = "*"
 
 [dev-dependencies]
-anyhow = "1.0"
-reqwest = { version="0.11", features=["blocking"] }
-sxd-xpath = "0.4"
+anyhow = "1.0.68"
+reqwest = { version="0.11.13", features=["blocking"] }
+sxd-xpath = "0.4.2"


### PR DESCRIPTION
- Pin the version of dev-dependencies to the latest version.
- For dependencies, do not point to a specific version so that the user of this crate can control it.
