### PR TITLE
re-specify the dependencies version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["sxd_document", "sxd_xpath", "html5ever"]
 repository = "https://github.com/kitsuyui/sxd_html"
 
 [dependencies]
-html5ever = "*"
-sxd-document = "*"
+html5ever = ">= 0.24.0"
+sxd-document = ">= 0.3.0"
 
 [dev-dependencies]
 anyhow = "1.0.68"


### PR DESCRIPTION
I unpinned dependencies in this commit, but that was a mistake.
Specify the smallest version that you know works reliably.

https://github.com/kitsuyui/sxd_html/commit/8684a6967d6406644dc34c1ab235f8446dd02f6b
