### PR TITLE
Pin cargo.toml dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["sxd_document", "sxd_xpath", "html5ever"]
 repository = "https://github.com/kitsuyui/sxd_html"
 
 [dependencies]
-html5ever = ">= 0.24.0"
-sxd-document = ">= 0.3.0"
+html5ever = "0.24.0"
+sxd-document = "0.3.0"
 
 [dev-dependencies]
 anyhow = "1.0.68"


### PR DESCRIPTION
I made a mistake with this PR https://github.com/kitsuyui/sxd_html/pull/2

There is not much advantage to actually taking the version wider.

- Cargo.toml has the caret requirement equivalent of the semver rule in effect from the start.

- Therefore, even if Cargo.toml refers to a fixed version of a dependency, it is possible for users of this crate to use a version of the dependency that exceeds it.

- Also, the original attachment to semver should not be a destructive change to the API except for major version upgrades. (I'm not sure how many packages are actually protected.)
