### PR TITLE
Avoid duplicate pull_request and push in GitHub Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: publish crates
 
 on:
-  push:
   pull_request:
+    types: [opened, synchronize]
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,5 @@
 name: Spellcheck
 on:
-  - push
   - pull_request
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,5 @@
 name: tests
 on:
-  - push
   - pull_request
 jobs:
   tests:


### PR DESCRIPTION
push is not necessary if there is a pull_request synchronize
