### PR TITLE
Fix: CI send coverage condition

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: tests
 on:
-  - pull_request
+  # pull-request events are not triggered when a PR is merged
+  # push events are not triggered when a PR created from a fork repository
+  # So we need both to run tests on every PR and after merging
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
   tests:
     name: tests


### PR DESCRIPTION
- pull-request events are not triggered when a PR is merged
- push events are not triggered when a PR created from a fork repository
- So we need both to run tests on every PR and after merging
