### PR TITLE
Update html5ever to 0.29.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["sxd_document", "sxd_xpath", "html5ever"]
 repository = "https://github.com/kitsuyui/sxd_html"
 
 [dependencies]
-html5ever = "0.28.0"
+html5ever = "0.29.0"
 sxd-document = "0.3.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@ use std::{
     convert::TryFrom,
 };
 
-use html5ever::driver::ParseOpts;
 use html5ever::tendril::TendrilSink;
 use html5ever::tree_builder::TreeBuilderOpts;
+use html5ever::{driver::ParseOpts, ExpandedName};
 
 pub use error::Error;
 pub(crate) use handle::Handle;
@@ -46,6 +46,7 @@ impl<'d> DocHtmlSink<'d> {
 }
 
 impl<'d> TreeSink for DocHtmlSink<'d> {
+    type ElemName<'a> = ExpandedName<'a> where Self: 'a;
     type Handle = Handle<'d>;
     type Output = Vec<Error>;
 
@@ -67,7 +68,7 @@ impl<'d> TreeSink for DocHtmlSink<'d> {
     }
 
     // this is only called on elements
-    fn elem_name<'h>(&'h self, target: &'h Self::Handle) -> html5ever::ExpandedName<'h> {
+    fn elem_name<'h>(&'h self, target: &'h Self::Handle) -> Self::ElemName<'h> {
         match target {
             Handle::Element(_, qualname, _) => qualname.expanded(),
             _ => panic!("not an element"),


### PR DESCRIPTION
- Implement ElemName to adapt type changes in html5ever 0.29.0
