### PR TITLE
Fix: format trailing where clauses in type aliases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,10 @@ impl<'d> DocHtmlSink<'d> {
 }
 
 impl<'d> TreeSink for DocHtmlSink<'d> {
-    type ElemName<'a> = ExpandedName<'a> where Self: 'a;
+    type ElemName<'a>
+        = ExpandedName<'a>
+    where
+        Self: 'a;
     type Handle = Handle<'d>;
     type Output = Vec<Error>;
 


### PR DESCRIPTION
> rustfmt now formats trailing where clauses in type aliases
https://github.com/rust-lang/rustfmt/blob/master/CHANGELOG.md#added

I've run `cargo fmt` to fix the issue.
