### PR TITLE
Update html5ever

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["sxd_document", "sxd_xpath", "html5ever"]
 repository = "https://github.com/kitsuyui/sxd_html"
 
 [dependencies]
-html5ever = "0.30.0"
+html5ever = "0.35.0"
 sxd-document = "0.3.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,7 @@ pub fn parse_html_fragment_with_errors(contents: &str) -> (Package, Vec<Error>) 
         opts,
         QualName::new(None, Namespace::default(), LocalName::from("")),
         Default::default(),
+        false,
     );
     let errors = parser.one(contents);
 


### PR DESCRIPTION
- Update html5ever to version 0.35.0
- html5ever::parse_fragment now requires the `context_element_allows_scripting` argument.
