### PR TITLE
Update gitignore-in/gh-action to v0.2.3

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -13,4 +13,4 @@ jobs:
   update-gitignore:
     runs-on: ubuntu-latest
     steps:
-      - uses: gitignore-in/gh-action@v0.2.2
+      - uses: gitignore-in/gh-action@v0.2.3


### PR DESCRIPTION
## Summary
- update `gitignore-in/gh-action` from `v0.2.2` to `v0.2.3`
- use the latest released action for the scheduled gitignore update workflow

## Testing
- `git diff --check`
