### PR TITLE
ci: Split publish workflow by trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: publish crates
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -8,8 +10,34 @@ on:
     types: [prereleased, released]
 
 jobs:
+  publish-dryrun:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - run: cargo build --release --all-features
+
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: github.event_name == 'release'
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

- Split `publish.yml` by responsibility so `pull_request` runs build-only checks, and `release` runs publish-only workflow steps.
- Made workflow and job permissions explicit, using the minimum `contents: read` permission by default.
- Restricted `CARGO_REGISTRY_TOKEN` usage to the release job so PR checks do not require token access.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check`
- `cargo build --release --all-features`
- `cargo llvm-cov --lcov --output-path coverage.lcov` (not run because `llvm-cov` is not installed in this environment)
