### PR TITLE
fix: return Err(()) instead of panic in TryFrom<Handle> for ChildOfRoot

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -60,11 +60,11 @@ impl<'d> TryFrom<Handle<'d>> for ChildOfRoot<'d> {
     type Error = ();
     fn try_from(h: Handle<'d>) -> Result<Self, Self::Error> {
         match h {
-            Handle::Document(_) => panic!("Handle::Document cannot be made into ChildOfRoot"),
+            Handle::Document(_) => Err(()),
             Handle::Element(x, _, _) => Ok(x.into()),
             Handle::Comment(x) => Ok(x.into()),
             Handle::ProcessingInstruction(x) => Ok(x.into()),
-            Handle::Text(_) => panic!("Handle::Text cannot be made into ChildOfRoot"),
+            Handle::Text(_) => Err(()),
         }
     }
 }


### PR DESCRIPTION
## Summary

`TryFrom<Handle<'d>> for ChildOfRoot<'d>` violated the `TryFrom` contract by
calling `panic!` for `Handle::Document` and `Handle::Text` variants instead of
returning `Err(())`.

The `TryFrom` trait guarantees that conversion failures are expressed as `Err`,
allowing callers to use `?` or `.ok()` safely. The previous implementation
would unexpectedly panic even when the caller had written `try_from(h).ok()`
or used `?` expecting a graceful failure path.

## Changes

- `src/handle.rs`: Replace two `panic!` calls with `Err(())` in the
  `TryFrom<Handle>` implementation for `ChildOfRoot`

The callers in `src/util.rs` use `.expect(...)` with `#[allow(clippy::expect_used)]`
to explicitly document that panics at those sites are intentional programming
assertions (TreeSink invariant). These are unchanged — they are explicit about
their panic intent.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy --all-targets --all-features -- -D warnings`: pass (0 warnings)
- `cargo test`: 5/5 tests pass
- `cargo audit`: 0 vulnerabilities
