### PR TITLE
Expose parse error details in the public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 [![license](https://img.shields.io/crates/l/sxd_html)](https://github.com/kitsuyui/sxd_html#license)
 
 Uses the `html5ever` to parse html and convert it to a `sxd_document::Package` to use with `sxd_xpath`.
+
+`parse_html` and `parse_html_fragment` intentionally return only the parsed
+`sxd_document::Package`. If callers need to inspect html5ever parse errors,
+use `parse_html_with_errors` or `parse_html_fragment_with_errors`:
+
+```rust
+let (package, errors) = sxd_html::parse_html_with_errors(contents);
+for error in &errors {
+    eprintln!("line {}: {}", error.line(), error.message());
+}
+```
+
 ## Example
 ```rust
 use sxd_xpath::{nodeset::Node, Context, Error, Factory, Value};

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,19 @@
 #[derive(Debug)]
 pub struct Error(u64, String);
+
 impl Error {
     pub(crate) fn new(line: u64, msg: impl Into<String>) -> Self {
         Self(line, msg.into())
+    }
+
+    /// Returns the input line where html5ever reported this parse error.
+    pub fn line(&self) -> u64 {
+        self.0
+    }
+
+    /// Returns html5ever's parse error message.
+    pub fn message(&self) -> &str {
+        &self.1
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,10 @@ impl<'d> TreeSink for DocHtmlSink<'d> {
 
 /// Parses an HTML document and returns the result as a [`Package`].
 ///
+/// This convenience function discards parse errors. Use
+/// [`parse_html_with_errors`] when callers need to inspect html5ever parse
+/// errors.
+///
 /// # Note
 ///
 /// DOCTYPE declarations are silently dropped. `sxd_document` has no DOCTYPE node type,
@@ -267,6 +271,10 @@ pub fn parse_html(contents: &str) -> Package {
 
 /// Parses an HTML fragment and returns the result as a [`Package`].
 ///
+/// This convenience function discards parse errors. Use
+/// [`parse_html_fragment_with_errors`] when callers need to inspect html5ever
+/// parse errors.
+///
 /// # Note
 ///
 /// DOCTYPE declarations are silently dropped. `sxd_document` has no DOCTYPE node type,
@@ -276,7 +284,7 @@ pub fn parse_html_fragment(contents: &str) -> Package {
     parse_html_fragment_with_errors(contents).0
 }
 
-/// Parses an HTML document and returns the result and any parse errors as a [`Package`].
+/// Parses an HTML document and returns the result and any html5ever parse errors as a [`Package`].
 ///
 /// # Note
 ///
@@ -302,7 +310,7 @@ pub fn parse_html_with_errors(contents: &str) -> (Package, Vec<Error>) {
     (package, errors)
 }
 
-/// Parses an HTML fragment and returns the result and any parse errors as a [`Package`].
+/// Parses an HTML fragment and returns the result and any html5ever parse errors as a [`Package`].
 ///
 /// # Note
 ///

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -43,4 +43,16 @@ mod tests {
 
         assert_eq!("bye", c2.text());
     }
+
+    #[test]
+    fn parse_errors_are_inspectable() {
+        let contents = "<!DOCTYPE html>\n<html><body><p></div></body></html>";
+        let (_package, errors) = sxd_html::parse_html_with_errors(contents);
+
+        let error = errors
+            .first()
+            .expect("mismatched tags should produce a parse error");
+        assert!(error.line() > 0);
+        assert!(!error.message().is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

This change documents that the convenience parsing APIs discard parse errors, exposes `Error::line()` and `Error::message()` for programmatic inspection, and adds regression coverage for inspectable parse errors.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check`
- `cargo test`
- `cargo build --release --all-features`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- `git diff --check`

## Notes

The remote reusable spellcheck workflow is left to CI because this repository does not have a local spellcheck runner/config available here.
