### PR TITLE
fix: make AppendText-to-document-root invariant explicit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,9 +121,22 @@ impl<'d> TreeSink for DocHtmlSink<'d> {
     fn append(&self, parent: &Self::Handle, child: NodeOrText<Self::Handle>) {
         match parent {
             Handle::Document(root) => {
-                // text cant be appended to root so no need to concatenate it
-                let child = util::node_or_text_into_child_of_root(child);
-                root.append_child(child);
+                // html5ever's foster parenting mechanism redirects text nodes to the
+                // nearest enclosing element, so AppendText should never reach this branch.
+                // Explicit match makes the invariant visible; unreachable!() fires if
+                // a future html5ever version breaks the assumption.
+                match child {
+                    NodeOrText::AppendNode(_) => {
+                        let child = util::node_or_text_into_child_of_root(child);
+                        root.append_child(child);
+                    }
+                    NodeOrText::AppendText(_) => {
+                        unreachable!(
+                            "AppendText to document root should never occur: \
+                             html5ever's foster parenting redirects text nodes to elements"
+                        )
+                    }
+                }
             }
             Handle::Element(elem, _, _) => {
                 let last = elem.children().into_iter().last();


### PR DESCRIPTION
## Summary

The `append` method's `Handle::Document` branch passed the `child`
argument directly to `node_or_text_into_child_of_root`, which panics on
`AppendText`. The comment above the call read "text cant be appended to
root so no need to concatenate it", implying the `AppendText` case was
being safely skipped — but it was not; it would panic.

In practice html5ever's foster parenting mechanism redirects all text
nodes to an enclosing element before they reach the document root, so
the panic path is never triggered. However, the Rust type system cannot
enforce this invariant, and the comment was actively misleading to
anyone reading or extending the code.

## Changes

- Replaced the implicit passthrough with an explicit `match` on
  `NodeOrText`: the `AppendNode` arm preserves the original behaviour,
  while the `AppendText` arm calls `unreachable!()` with a message that
  names the html5ever invariant.
- The old comment is replaced by a short explanation of why
  `AppendText` cannot appear here and why `unreachable!()` is used.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
```

All checks pass locally.
