### PR TITLE
Preserve SVG and MathML namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ will be interpreted as
 So if you run the query `//table/tr/td`, you will not get the `td` hidden by `tbody`.
 You need to run the query `//table/tbody/tr/td`.
 
+HTML elements are stored without the XHTML namespace so existing unprefixed XPath queries such as
+`//article/h1/a` keep working. Embedded SVG and MathML elements keep their HTML5 namespaces. Register
+the namespace prefix on the XPath context before querying those elements:
+
+```rust
+let mut context = Context::new();
+context.set_namespace("svg", "http://www.w3.org/2000/svg");
+```
+
 ## License
 
 Licensed under either of

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,13 +8,15 @@ use sxd_document::{
 
 use crate::Handle;
 
+const HTML_NAMESPACE: &str = "http://www.w3.org/1999/xhtml";
+
 pub fn qualname_as_qname<'a>(qualname: &'a QualName) -> QName<'a> {
-    // let ns = if qualname.ns.is_empty() {
-    //     None
-    // } else {
-    //     Some(qualname.ns.as_ref())
-    // };
-    QName::with_namespace_uri(None, qualname.local.as_ref())
+    let namespace_uri = match qualname.ns.as_ref() {
+        "" | HTML_NAMESPACE => None,
+        namespace_uri => Some(namespace_uri),
+    };
+
+    QName::with_namespace_uri(namespace_uri, qualname.local.as_ref())
 }
 
 pub fn node_or_text_into_child_of_root(node_or_text: NodeOrText<Handle>) -> ChildOfRoot {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,9 @@
 #[cfg(test)]
 mod tests {
+    use sxd_xpath::{Context, Factory, Value};
+
+    const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
+
     #[test]
     fn parse_simple() {
         let contents = "<!DOCTYPE html><html><div>hello<br>bye</div></html>";
@@ -12,6 +16,7 @@ mod tests {
             .expect("html should be root element");
 
         assert_eq!("html", root.name().local_part());
+        assert!(root.name().namespace_uri().is_none());
 
         let children = root.children();
         // head and body are added if not present
@@ -21,15 +26,18 @@ mod tests {
         let body = children[1].element().unwrap();
 
         assert_eq!("head", head.name().local_part());
+        assert!(head.name().namespace_uri().is_none());
         assert_eq!(0, head.children().len());
 
         let children = body.children();
         assert_eq!("body", body.name().local_part());
+        assert!(body.name().namespace_uri().is_none());
         assert_eq!(1, children.len());
 
         let c0 = children[0].element().unwrap();
         let children = c0.children();
         assert_eq!("div", c0.name().local_part());
+        assert!(c0.name().namespace_uri().is_none());
         assert_eq!(3, children.len());
 
         let c0 = children[0].text().unwrap();
@@ -42,5 +50,30 @@ mod tests {
         assert_eq!(0, c1.children().len());
 
         assert_eq!("bye", c2.text());
+    }
+
+    #[test]
+    fn preserves_svg_namespace_for_xpath() {
+        let contents = concat!(
+            "<!DOCTYPE html><html><body>",
+            r#"<svg width="10"><circle id="dot"></circle></svg>"#,
+            "</body></html>",
+        );
+        let (package, errors) = sxd_html::parse_html_with_errors(contents);
+        assert_eq!(0, errors.len());
+
+        let factory = Factory::new();
+        let expression = factory.build("//svg:circle").unwrap().unwrap();
+        let root = package.as_document().root();
+        let mut context = Context::new();
+        context.set_namespace("svg", SVG_NAMESPACE);
+
+        let value = expression.evaluate(&context, root).unwrap();
+        let nodes = match value {
+            Value::Nodeset(nodes) => nodes,
+            _ => panic!("expected node set"),
+        };
+
+        assert_eq!(1, nodes.size());
     }
 }


### PR DESCRIPTION
## Summary
- Preserve non-HTML namespace URIs when converting parsed names into `sxd_document::QName`.
- Keep ordinary HTML elements without the XHTML namespace so existing unprefixed XPath examples continue to work.
- Document how to register XPath prefixes for embedded SVG and MathML elements.

## Tests
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check`
- `cargo build --release --all-features`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `git diff --check`

Note: spellcheck is covered by the repository's remote reusable workflow.
