### PR TITLE
fix: validate new_node before removing siblings in append_before_sibling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use html5ever::{
     LocalName, Namespace, QualName,
 };
 use sxd_document::{
-    dom::{ChildOfElement, Document},
+    dom::{ChildOfElement, Document, ParentOfChild},
     Package,
 };
 
@@ -191,6 +191,14 @@ impl<'d> TreeSink for DocHtmlSink<'d> {
     fn append_before_sibling(&self, sibling: &Self::Handle, new_node: NodeOrText<Self::Handle>) {
         #[allow(clippy::expect_used)]
         let parent = sibling.parent().expect("must have a parent");
+
+        // Validate new_node against the parent type *before* mutating the DOM.
+        // parent_of_child_append_node_or_text panics when the parent is Root and
+        // new_node is AppendText. Panicking after siblings are removed would leave the
+        // tree in a partial state with those siblings permanently lost.
+        if let (ParentOfChild::Root(_), NodeOrText::AppendText(_)) = (&parent, &new_node) {
+            panic!("Text cannot be made into ChildOfRoot");
+        }
 
         let children = {
             #[allow(clippy::expect_used)]


### PR DESCRIPTION
## Summary

`append_before_sibling()` performs a multi-step DOM mutation:

1. Collect the sibling and its following siblings.
2. Remove them all from the parent.
3. Append `new_node` to the parent *(can panic)*.
4. Re-append the collected siblings.

If step 3 panics — specifically when the parent is a `Root` node and
`new_node` is `AppendText` — the siblings removed in step 2 are never
re-inserted. The tree is left in a permanently inconsistent state.

The panic is triggered inside `parent_of_child_append_node_or_text` →
`node_or_text_into_child_of_root` for the `AppendText` variant.
html5ever's foster parenting guarantees that `Root + AppendText` does not
occur in normal HTML parsing, so the path is currently unreachable. However,
a caller using `catch_unwind` to recover from panics would receive an
incomplete DOM — missing any siblings that had been removed.

## Changes

- Import `ParentOfChild` in `src/lib.rs`.
- Add an upfront guard in `append_before_sibling` that mirrors the panic
  condition in `parent_of_child_append_node_or_text`. The panic now fires
  *before* any siblings are removed, so the DOM is never left in a partial
  state.

## Test plan

- `cargo test` — all existing tests pass
- `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- `cargo fmt --all -- --check` — no formatting issues
