### PR TITLE
refactor: break circular module dependency between handle and util

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -5,8 +5,6 @@ use sxd_document::dom::{
     ChildOfElement, ChildOfRoot, Comment, Element, ParentOfChild, ProcessingInstruction, Root, Text,
 };
 
-use crate::util;
-
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum Handle<'d> {
     Document(Root<'d>),
@@ -78,7 +76,12 @@ impl<'d> TryFrom<Handle<'d>> for ChildOfElement<'d> {
 
 impl<'d> From<Element<'d>> for Handle<'d> {
     fn from(e: Element<'d>) -> Self {
-        let qualname = util::qualname_from_qname(e.name());
+        let name = e.name();
+        let qualname = QualName::new(
+            None,
+            name.namespace_uri().unwrap_or_default().into(),
+            name.local_part().into(),
+        );
         Self::Element(e, qualname, false)
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,14 +8,6 @@ use sxd_document::{
 
 use crate::Handle;
 
-pub fn qualname_from_qname(qname: QName) -> QualName {
-    QualName::new(
-        None,
-        qname.namespace_uri().unwrap_or_default().into(),
-        qname.local_part().into(),
-    )
-}
-
 pub fn qualname_as_qname<'a>(qualname: &'a QualName) -> QName<'a> {
     // let ns = if qualname.ns.is_empty() {
     //     None


### PR DESCRIPTION
## Summary

Removes the circular module dependency between `src/handle.rs` and `src/util.rs`.

Previously, `handle.rs` imported `util` (to call `util::qualname_from_qname`), while `util.rs` imported `Handle` from `handle.rs` via the crate root. This created a bidirectional design dependency: `handle.rs → util.rs → handle.rs`.

After this change the dependency is strictly one-directional: `util.rs` depends on `Handle`, but `handle.rs` has no dependency on `util.rs`.

## Changes

- `src/handle.rs`: removed `use crate::util;` and inlined the `QName → QualName` conversion directly at the call site
- `src/util.rs`: removed `qualname_from_qname`, which was only used by `handle.rs` and is now dead code

## Verification

- `cargo fmt --all`: no changes
- `cargo clippy --all-targets --all-features -- -D warnings`: no warnings
- `cargo test`: all 5 tests pass (4 unit tests, 1 integration test)
