### PR TITLE
Make Handle variant invariants explicit via is_template and track_caller

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -18,6 +18,19 @@ pub enum Handle<'d> {
 }
 
 impl<'d> Handle<'d> {
+    /// Returns `true` if this handle is a template `Element` (html5ever
+    /// `ElementFlags::template == true`).  Call this before
+    /// `get_template_contents` to avoid a panic.
+    pub(crate) fn is_template(&self) -> bool {
+        matches!(self, Self::Element(_, _, true))
+    }
+
+    /// Returns a reference to the inner `Element`.
+    ///
+    /// # Panics
+    /// Panics if `self` is not `Handle::Element`.  html5ever only calls this
+    /// on element nodes (invariant documented in `TreeSink::elem_name`).
+    #[track_caller]
     pub fn element_ref(&self) -> &Element<'d> {
         match self {
             Self::Element(e, _, _) => e,
@@ -25,6 +38,12 @@ impl<'d> Handle<'d> {
         }
     }
 
+    /// Returns the parent of this node.
+    ///
+    /// # Panics
+    /// Panics if `self` is `Handle::Document` — the document root has no
+    /// parent.  html5ever never calls `parent()` on the document handle.
+    #[track_caller]
     pub fn parent(&self) -> Option<ParentOfChild<'d>> {
         match self {
             Self::Document(_) => panic!("Cannot call parent on Document"),
@@ -35,6 +54,11 @@ impl<'d> Handle<'d> {
         }
     }
 
+    /// Returns the siblings that follow this node in document order.
+    ///
+    /// # Panics
+    /// Panics if `self` is `Handle::Document`.
+    #[track_caller]
     pub fn following_siblings(&self) -> Vec<ChildOfElement<'d>> {
         match self {
             Self::Document(_) => panic!("Cannot call following_siblings on Document"),
@@ -45,6 +69,11 @@ impl<'d> Handle<'d> {
         }
     }
 
+    /// Detaches this node from its parent.
+    ///
+    /// # Panics
+    /// Panics if `self` is `Handle::Document`.
+    #[track_caller]
     pub fn remove_from_parent(&self) {
         match self {
             Self::Document(_) => panic!("Cannot call remove_from_parent on Document"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,11 +173,11 @@ impl<'d> TreeSink for DocHtmlSink<'d> {
     }
 
     fn get_template_contents(&self, target: &Self::Handle) -> Self::Handle {
-        // this template stuff is probably not well done but seems to work
-        match target {
-            Handle::Element(_, _, true) => target.clone(),
-            _ => panic!("not a template element"),
-        }
+        assert!(
+            target.is_template(),
+            "get_template_contents called on non-template element"
+        );
+        target.clone()
     }
 
     fn same_node(&self, x: &Self::Handle, y: &Self::Handle) -> bool {


### PR DESCRIPTION
## Summary

`Handle::Element(elem, qualname, bool)` carries a raw `bool` flag to indicate
template status, but no method exposed this semantics — callers had to pattern-
match `Handle::Element(_, _, true)` directly. Similarly, methods like
`element_ref()`, `parent()`, `following_siblings()`, and `remove_from_parent()`
panic on certain variants with messages that give no call-site context.

This PR makes these implicit contracts explicit in two ways:

1. **`Handle::is_template() -> bool`** — a `pub(crate)` helper that answers the
   template question without exposing the raw `bool` position.
   `get_template_contents` now calls `assert!(target.is_template(), …)` instead
   of a bare `match` arm with an opaque `panic!`, making the precondition
   self-documenting.

2. **`#[track_caller]`** on all four panicking methods — when a caller invariant
   is violated the panic message now points to the call site, not the match arm
   deep inside `handle.rs`.

3. **Doc comments** on each panicking method that state which variants are valid
   and reference the html5ever caller contract that protects each site.

No behavior change; all existing tests pass.

## Changes

- `src/handle.rs`: Added `is_template()`, `#[track_caller]`, and doc comments
  to `element_ref`, `parent`, `following_siblings`, `remove_from_parent`.
- `src/lib.rs`: Replaced ad-hoc match in `get_template_contents` with
  `assert!(target.is_template(), …)`.

## Verification

```
cargo test   # 5 tests pass (4 unit + 1 integration)
cargo clippy # no findings
cargo fmt    # no changes
```

## Trade-offs

- `is_template()` is `pub(crate)` — not a public API commitment.
- The `bool` field in `Handle::Element` is unchanged; a future `structural`
  refactor could split it into `Element` / `TemplateElement` variants for full
  type-level guarantees, but that scope is larger and out of line for this fix.