### PR TITLE
Add cargo-deny advisory config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,28 @@
+[advisories]
+# Deny known security vulnerabilities; warn on unmaintained crates.
+# sxd-document and sxd-xpath have no upstream activity since ~2021 and are
+# knowingly used as core dependencies. No RUSTSEC advisories exist for them
+# today. This config will surface any future advisories immediately via CI.
+ignore = []
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "OpenSSL",
+]
+confidence-threshold = 0.8
+exceptions = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

Adds `deny.toml` (cargo-deny configuration) to make the project's
dependency advisory monitoring explicit.

`sxd-document` and `sxd-xpath` — the core dependencies of this library —
have had no upstream releases or commits since ~2021. There are no known
RUSTSEC security advisories against them today. This PR documents that
status and puts advisory monitoring infrastructure in place so that any
future security advisories filed against these or any other dependency
are surfaced immediately.

## Changes

- `deny.toml`: cargo-deny config with `[advisories]`, `[licenses]`,
  `[bans]`, and `[sources]` sections. Configured to deny known
  vulnerabilities and warn on unmaintained crates.

## Verification

```
cargo deny check advisories  # advisories ok
cargo deny check licenses    # licenses ok
cargo deny check bans sources  # bans ok, sources ok
```

## Trade-offs

- The `deny.toml` alone requires `cargo deny` to be run manually or
  wired up in CI. A follow-up to add `cargo deny check advisories` to
  `.github/workflows/test.yml` would complete the CI integration.
- `sxd-document` and `sxd-xpath` remain the core dependencies; this
  PR does not change that. It makes the ongoing reliance on them
  explicit and machine-checkable.
