### PR TITLE
Remove HTTP client dependency from example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,4 @@ sxd-document = "0.3.2"
 
 [dev-dependencies]
 anyhow = "1.0.82"
-reqwest = { version="0.13.0", features=["blocking"] }
 sxd-xpath = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,29 @@ Uses the `html5ever` to parse html and convert it to a `sxd_document::Package` t
 use sxd_xpath::{nodeset::Node, Context, Error, Factory, Value};
 
 fn main() -> anyhow::Result<()> {
-    let contents = reqwest::blocking::get("https://github.com/trending")?.text()?;
-    let package = sxd_html::parse_html(&contents);
+    let contents = r#"
+<!doctype html>
+<html lang="en">
+  <body>
+    <article>
+      <h1>
+        <a href="/rust-lang/rust"><span>rust-lang</span> /rust</a>
+      </h1>
+    </article>
+    <article>
+      <h1>
+        <a href="/tokio-rs/tokio"><span>tokio-rs</span> /tokio</a>
+      </h1>
+    </article>
+    <article>
+      <h1>
+        <a href="/hyperium/hyper"><span>hyperium</span> /hyper</a>
+      </h1>
+    </article>
+  </body>
+</html>
+"#;
+    let package = sxd_html::parse_html(contents);
     let document = package.as_document();
 
     let mut trending_repos: Vec<String> = Default::default();
@@ -36,7 +57,7 @@ fn main() -> anyhow::Result<()> {
 
     println!("Trending Repos :");
     for name in trending_repos {
-        println!("\t{}", name);
+        println!("\t{name}");
     }
 
     Ok(())
@@ -55,34 +76,12 @@ fn evaluate_xpath_node<'d>(node: impl Into<Node<'d>>, expr: &str) -> Result<Valu
 }
 ```
 
-Output (01/07/2021):
+Output:
 ```
 Trending Repos :
-	GTAmodding /re3
-	jina-ai /jina
-	JetBrains /kotlin
-	freefq /free
-	prisma /prisma
-	rcmaehl /WhyNotWin11
-	bytedance /lightseq
-	covidpass-org /covidpass
-	pi-apps /pi-platform-docs
-	yangshun /front-end-interview-handbook
-	amit-davidson /awesome-golang-workshops
-	mhadidg /software-architecture-books
-	30-seconds /30-seconds-of-code
-	GokuMohandas /MadeWithML
-	dataease /dataease
-	ffffffff0x /Digital-Privacy
-	trekhleb /javascript-algorithms
-	PaddlePaddle /PaddleX
-	SigNoz /signoz
-	sudheerj /reactjs-interview-questions
-	EdgeSecurityTeam /Vulnerability
-	dastergon /awesome-sre
-	PowerShell /PowerShell
-	CorentinJ /Real-Time-Voice-Cloning
-	csseky /cskaoyan
+	rust-lang/rust
+	tokio-rs/tokio
+	hyperium/hyper
 ```
 
 ## Note

--- a/examples/github_trending.html
+++ b/examples/github_trending.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <article>
+      <h1>
+        <a href="/rust-lang/rust"><span>rust-lang</span> /rust</a>
+      </h1>
+    </article>
+    <article>
+      <h1>
+        <a href="/tokio-rs/tokio"><span>tokio-rs</span> /tokio</a>
+      </h1>
+    </article>
+    <article>
+      <h1>
+        <a href="/hyperium/hyper"><span>hyperium</span> /hyper</a>
+      </h1>
+    </article>
+  </body>
+</html>

--- a/examples/github_trending.rs
+++ b/examples/github_trending.rs
@@ -1,8 +1,8 @@
 use sxd_xpath::{nodeset::Node, Context, Error, Factory, Value};
 
 fn main() -> anyhow::Result<()> {
-    let contents = reqwest::blocking::get("https://github.com/trending")?.text()?;
-    let package = sxd_html::parse_html(&contents);
+    let contents = include_str!("github_trending.html");
+    let package = sxd_html::parse_html(contents);
     let document = package.as_document();
 
     let mut trending_repos: Vec<String> = Default::default();


### PR DESCRIPTION
## Summary

- Remove the `reqwest` dev-dependency from the example-only dependency set.
- Replace the live GitHub Trending fetch with a checked-in HTML fixture.
- Update the README example and output so it is deterministic and does not require network access.

## Verification

- `cargo run --example github_trending`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check`
- `cargo test --all-features`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `cargo build --release --all-features`
- `cargo check --examples`
- `cargo package --allow-dirty --list | rg "examples/github_trending|Cargo.toml|README.md"`
- `cargo publish --dry-run --allow-dirty`
- `actionlint`
- `typos`
- `git diff --check`
- `cargo tree -e normal,dev -p sxd_html | rg "reqwest|tokio|hyper|rustls|aws-lc-rs|quinn" || true` (no matches)
- implement-validator: overall pass
