### PR TITLE
Add coverage threshold for octocov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,4 @@ jobs:
 
       - run: cargo check
 
-      - name: coverage
-        run: |
-          cargo install cargo-llvm-cov || true  # when already cached
-          cargo llvm-cov --lcov --output-path coverage.lcov
-
+      - run: cargo test --all-targets --all-features

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,6 +2,7 @@
 coverage:
   paths:
     - coverage.lcov
+  acceptable: 65%
 codeToTestRatio:
   code:
     - "src/**/*.rs"


### PR DESCRIPTION
## Summary
- Add a 65% octocov coverage acceptance threshold.
- Keep the tests workflow focused on Rust checks and tests.
- Leave coverage generation to the octocov workflow so CI does not collect it twice.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check`
- `cargo test --all-targets --all-features`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `cargo llvm-cov report --summary-only`
- local octocov CLI run against `.octocov.yml` and `coverage.lcov` reported 67.2% coverage
- `typos .octocov.yml .github/workflows/test.yml`
- `actionlint .github/workflows/test.yml .github/workflows/octocov.yml .github/workflows/spellcheck.yml .github/workflows/publish.yml`
- `git diff --check`
