### PR TITLE
Verify release tag matches crate version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,8 @@ jobs:
 
       - run: cargo build --release --all-features
 
+      - run: scripts/test-check-cargo-version-tag.sh
+
   publish:
     runs-on: ubuntu-latest
     permissions:
@@ -59,6 +61,9 @@ jobs:
       - run: cargo test --all-features
 
       - run: cargo build --release --all-features
+
+      - name: verify release tag matches Cargo.toml version
+        run: scripts/check-cargo-version-tag.sh "${GITHUB_REF_NAME}"
 
       - name: publish (dry-run)
         if: github.event_name == 'release' && github.event.release.prerelease

--- a/scripts/check-cargo-version-tag.sh
+++ b/scripts/check-cargo-version-tag.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Ensure a release tag publishes the same version as Cargo.toml.
+
+set -eu
+
+manifest_path=${CARGO_MANIFEST_PATH:-Cargo.toml}
+tag_name=${1:-${GITHUB_REF_NAME:-}}
+
+if [ -z "${tag_name}" ]; then
+	echo "Error: release tag name is required" >&2
+	exit 2
+fi
+
+case "${tag_name}" in
+refs/tags/*)
+	tag_name=${tag_name#refs/tags/}
+	;;
+esac
+
+tag_version=${tag_name#v}
+
+cargo_version=$(
+	awk '
+    /^\[package\]/ {
+      in_package = 1
+      next
+    }
+    /^\[/ && in_package {
+      in_package = 0
+    }
+    in_package && $1 == "version" && $2 == "=" {
+      gsub(/^"/, "", $3)
+      gsub(/"$/, "", $3)
+      print $3
+      exit
+    }
+  ' "${manifest_path}"
+)
+
+if [ -z "${cargo_version}" ]; then
+	echo "Error: package.version not found in ${manifest_path}" >&2
+	exit 1
+fi
+
+if [ "${cargo_version}" != "${tag_version}" ]; then
+	echo "Error: release tag '${tag_name}' does not match Cargo.toml version '${cargo_version}'" >&2
+	exit 1
+fi
+
+echo "Release tag '${tag_name}' matches Cargo.toml version '${cargo_version}'."

--- a/scripts/test-check-cargo-version-tag.sh
+++ b/scripts/test-check-cargo-version-tag.sh
@@ -17,16 +17,23 @@ CARGO_MANIFEST_PATH="${manifest}" scripts/check-cargo-version-tag.sh v1.2.3
 CARGO_MANIFEST_PATH="${manifest}" scripts/check-cargo-version-tag.sh 1.2.3
 CARGO_MANIFEST_PATH="${manifest}" scripts/check-cargo-version-tag.sh refs/tags/v1.2.3
 
-set +e
-output=$(CARGO_MANIFEST_PATH="${manifest}" scripts/check-cargo-version-tag.sh v1.2.4 2>&1)
-status=$?
-set -e
-[ "${status}" -eq 1 ]
-printf '%s\n' "${output}" | grep "does not match Cargo.toml version '1.2.3'"
+run_failure() {
+	expected_status=$1
+	output_file=$2
+	shift 2
 
-set +e
-output=$(CARGO_MANIFEST_PATH="${manifest}" scripts/check-cargo-version-tag.sh 2>&1)
-status=$?
-set -e
-[ "${status}" -eq 2 ]
-printf '%s\n' "${output}" | grep 'release tag name is required'
+	set +e
+	"$@" >"${output_file}" 2>&1
+	status=$?
+	set -e
+
+	[ "${status}" -eq "${expected_status}" ]
+}
+
+mismatch_output="${tmpdir}/mismatch.out"
+run_failure 1 "${mismatch_output}" env CARGO_MANIFEST_PATH="${manifest}" scripts/check-cargo-version-tag.sh v1.2.4
+grep "does not match Cargo.toml version '1.2.3'" "${mismatch_output}"
+
+missing_tag_output="${tmpdir}/missing-tag.out"
+run_failure 2 "${missing_tag_output}" env CARGO_MANIFEST_PATH="${manifest}" GITHUB_REF_NAME= scripts/check-cargo-version-tag.sh
+grep 'release tag name is required' "${missing_tag_output}"

--- a/scripts/test-check-cargo-version-tag.sh
+++ b/scripts/test-check-cargo-version-tag.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Exercise release tag and Cargo.toml version matching.
+
+set -eu
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+
+manifest="${tmpdir}/Cargo.toml"
+cat >"${manifest}" <<'TOML'
+[package]
+name = "example"
+version = "1.2.3"
+TOML
+
+CARGO_MANIFEST_PATH="${manifest}" scripts/check-cargo-version-tag.sh v1.2.3
+CARGO_MANIFEST_PATH="${manifest}" scripts/check-cargo-version-tag.sh 1.2.3
+CARGO_MANIFEST_PATH="${manifest}" scripts/check-cargo-version-tag.sh refs/tags/v1.2.3
+
+set +e
+output=$(CARGO_MANIFEST_PATH="${manifest}" scripts/check-cargo-version-tag.sh v1.2.4 2>&1)
+status=$?
+set -e
+[ "${status}" -eq 1 ]
+printf '%s\n' "${output}" | grep "does not match Cargo.toml version '1.2.3'"
+
+set +e
+output=$(CARGO_MANIFEST_PATH="${manifest}" scripts/check-cargo-version-tag.sh 2>&1)
+status=$?
+set -e
+[ "${status}" -eq 2 ]
+printf '%s\n' "${output}" | grep 'release tag name is required'


### PR DESCRIPTION
Summary:
- Add a release guard that compares the release tag with Cargo.toml package.version before publishing.
- Exercise the guard in the pull request publish dry-run workflow with a shell test.
- Keep the publish step from running when a release tag and crate version disagree.

Tests:
- git diff --check
- sh -n scripts/*.sh
- go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh
- shellcheck scripts/*.sh
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color
- scripts/test-check-cargo-version-tag.sh
- scripts/check-cargo-version-tag.sh v0.1.2
- typos
- cargo fmt --all -- --check
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features
- cargo build --release --all-features
