### PR TITLE
ci: add test workflow token permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   tests:
     name: tests


### PR DESCRIPTION
Summary
- Add explicit read-only contents permission to the test workflow.
- Keep the workflow behavior unchanged while avoiding repository-default token permissions.

Verification
- git diff --check
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color .github/workflows/test.yml
- collateral check: clean
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo check
- cargo test --all-targets --all-features
- cargo llvm-cov --lcov --output-path coverage.lcov
- cargo tree --duplicates (0 duplicates)
