### PR TITLE
ci: add push protection monitoring workflow

### DIFF
--- a/.github/workflows/check-push-protection.yml
+++ b/.github/workflows/check-push-protection.yml
@@ -1,0 +1,26 @@
+name: Check push protection
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check secret scanning push protection
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          status=$(gh api "repos/${{ github.repository }}" \
+            --jq '.security_and_analysis.secret_scanning_push_protection.status // "unknown"')
+          echo "Push protection: $status"
+          if [ "$status" != "enabled" ]; then
+            echo "::error::Secret scanning push protection is not enabled (status: $status)."
+            echo "::error::Enable it at: https://github.com/${{ github.repository }}/settings/security_analysis"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Add a weekly monitoring workflow that checks whether GitHub Secret Scanning
push protection is enabled. Push protection prevents secrets from being
committed in the first place; the repository currently has secret scanning
enabled but push protection disabled.

Because enabling push protection requires a repository admin action in
GitHub settings (Settings → Code security → Secret scanning → Push
protection), this PR adds a CI gate that fails with a clear error and a
direct link to the settings page when push protection is not enabled.

## Why a monitoring workflow instead of direct enablement

The GitHub API endpoint for enabling push protection requires admin scope.
A workflow using the default `GITHUB_TOKEN` can only read and verify the
status. The monitoring workflow surfaces the gap as a CI failure,
directing the maintainer to enable it via the repository settings.

## Test plan

- [ ] Workflow runs on schedule without errors once push protection is enabled
- [ ] `workflow_dispatch` triggers the check manually