### PR TITLE
ci: add cargo-deny workflow for license and advisory checks

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,0 +1,15 @@
+name: cargo-deny
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
+jobs:
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2


### PR DESCRIPTION
## Summary

Adds `.github/workflows/deny.yml` to wire the existing `deny.toml` into CI as a fail-close audit gate.

- Runs `EmbarkStudios/cargo-deny-action@v2` on every PR and push to `main`
- Checks license compliance, banned crates, and security advisories defined in `deny.toml`
- Kept as a dedicated workflow (separate from `test.yml`) for clear separation of concerns

## Changes

- `.github/workflows/deny.yml` — new workflow that runs `cargo deny check` on PR / push to main

## Verification

`deny.toml` was added in #112 with the following policy:
- **licenses**: MIT, Apache-2.0, Apache-2.0 WITH LLVM-exception, BSD-3-Clause, ISC, Unicode-3.0, OpenSSL
- **advisories**: deny known vulnerabilities (RUSTSEC advisory DB)
- **bans**: warn on multiple versions
- **sources**: crates.io only

This workflow exercises that config on every PR and main push, failing CI if a dependency violates the policy.

## Trade-offs

Action references use the same tag-ref style (`@v6`, `@v2`) as the existing `test.yml`. SHA pinning for actions is a separate concern and not introduced here.
